### PR TITLE
Automatically determine spacing amount when replacing all spaces with tabs

### DIFF
--- a/SkEditorPlus/Windows/FormattingWindow.xaml
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml
@@ -10,7 +10,7 @@
     <Grid>
         <CheckBox x:Name="variablesCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsVariablesCheckbox}" HorizontalAlignment="Left" Margin="10,24,0,0" VerticalAlignment="Top"/>
         
-        <CheckBox x:Name="spacesCheckBox" Background="{StaticResource RegionBrush}" ToolTip="For now it works only with 4 spaces per tab. Sorry!" ToolTipService.IsEnabled="True" ToolTipService.InitialShowDelay="10" Content="{DynamicResource QuickEditsSpacesCheckbox}" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top"/>
+        <CheckBox x:Name="spacesCheckBox" Background="{StaticResource RegionBrush}" ToolTip="Switches from spaces to tabs for indenting" ToolTipService.IsEnabled="True" ToolTipService.InitialShowDelay="10" Content="{DynamicResource QuickEditsSpacesCheckbox}" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top"/>
         
         <CheckBox x:Name="commentsCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsCommentsCheckbox}" HorizontalAlignment="Left" Margin="10,76,0,0" VerticalAlignment="Top" FontSize="12"/>
         <CheckBox x:Name="elseIfCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsElseIfCheckbox}" HorizontalAlignment="Left" Margin="10,102,0,0" VerticalAlignment="Top" FontSize="12"/>

--- a/SkEditorPlus/Windows/FormattingWindow.xaml.cs
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml.cs
@@ -109,8 +109,28 @@ namespace SkEditorPlus.Windows
 
         private void SpacesToTabs()
         {
-            // In future there will be a setting for spaces per tab
-            ConvertSpacesToTabs(4);
+            // Automatically detect the amount of spaces
+            int spacingAmount = DetectSpacingAmount();
+            ConvertSpacesToTabs(spacingAmount);
+        }
+
+        private int DetectSpacingAmount() {
+            var lines = textEditor.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+            var newLines = new List<string>();
+
+            for (int i = 0; i < lines.Count(); i++) 
+            {
+                string line = lines[i];
+                int spaces = line.TakeWhile(c => c == ' ').Count();
+                if (spaces == 0 && line.Length > 0 && line[0] != '#' && !Char.IsWhiteSpace(line[0]) && lines.Length > i + 1)
+                {
+                    int spacing = lines[i+1].TakeWhile(c => c == ' ').Count();
+                    return spacing;
+                }
+            }
+            //Default Return
+            return 4;
         }
 
         private void ConvertSpacesToTabs(int spacePerTab)
@@ -124,6 +144,13 @@ namespace SkEditorPlus.Windows
                 for (int i = 0; i < lines.Length; i++)
                 {
                     string lineToReplace = lines[i];
+
+                    //Don't affect comments
+                    if (lineToReplace.Trim().Length > 0 && lineToReplace.Trim()[0] == '#')
+                    {
+                        newLines.Add(lineToReplace);
+                        continue;
+                    }
 
                     int spaces = lineToReplace.TakeWhile(c => c == ' ').Count();
 


### PR DESCRIPTION
Using the "Replace spaces with tab" option in the Quick Edit menu will now automatically detect the spacing amount used in the file, and replace accordingly.