### PR TITLE
Add new "change tabs to spaces" quick edit

### DIFF
--- a/SkEditorPlus/Languages/English.xaml
+++ b/SkEditorPlus/Languages/English.xaml
@@ -96,6 +96,7 @@
     
     <system:String x:Key="QuickEditsVariablesCheckbox">Change dots in variables to colons</system:String>
     <system:String x:Key="QuickEditsSpacesCheckbox">Change spaces to tabs</system:String>
+    <system:String x:Key="QuickEditsTabsCheckbox">Change tabs to 4 spaces</system:String>
     <system:String x:Key="QuickEditsCommentsCheckbox">Remove comments</system:String>
     <system:String x:Key="QuickEditsElseIfCheckbox">Shorten "else if"</system:String>
     

--- a/SkEditorPlus/Windows/FormattingWindow.xaml
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml
@@ -10,11 +10,19 @@
     <Grid>
         <CheckBox x:Name="variablesCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsVariablesCheckbox}" HorizontalAlignment="Left" Margin="10,24,0,0" VerticalAlignment="Top"/>
         
-        <CheckBox x:Name="spacesCheckBox" Background="{StaticResource RegionBrush}" ToolTip="Switches from spaces to tabs for indenting" ToolTipService.IsEnabled="True" ToolTipService.InitialShowDelay="10" Content="{DynamicResource QuickEditsSpacesCheckbox}" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top"/>
+        <RadioButton x:Name="spacesCheckBox" Checked="Radio_Checked" Click="Radio_Clicked" GroupName="SpacesAndTabs" Background="{StaticResource RegionBrush}" ToolTip="Switches from spaces to tabs for indenting" ToolTipService.IsEnabled="True" ToolTipService.InitialShowDelay="10" Content="{DynamicResource QuickEditsSpacesCheckbox}" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top"/>
+
+        <RadioButton x:Name="tabsCheckBox" Checked="Radio_Checked" Click="Radio_Clicked" GroupName="SpacesAndTabs" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsTabsCheckbox}" HorizontalAlignment="Left" Margin="10,76,0,0" VerticalAlignment="Top" FontSize="12"/>
+        <Button x:Name="cmdUp" x:FieldModifier="private" FontSize="10" Content="▲" Width="12"  Background="Transparent" Height="10" Click="spaceUp_Click" Padding="0,-4,0,0" Margin="162,78,1,13" HorizontalAlignment="Left" VerticalAlignment="Top"  BorderThickness="0"  
+    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" />
+        <Button x:Name="cmdDown" x:FieldModifier="private" FontSize="10" Content="▼" Width="12" Height="10"  Background="Transparent" Click="spaceDown_Click" Padding="0,-4,0,0" Margin="162,88,1,3" HorizontalAlignment="Left" VerticalAlignment="Top"  BorderThickness="0"  
+    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" />
         
-        <CheckBox x:Name="commentsCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsCommentsCheckbox}" HorizontalAlignment="Left" Margin="10,76,0,0" VerticalAlignment="Top" FontSize="12"/>
-        <CheckBox x:Name="elseIfCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsElseIfCheckbox}" HorizontalAlignment="Left" Margin="10,102,0,0" VerticalAlignment="Top" FontSize="12"/>
+        
+        <CheckBox x:Name="commentsCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsCommentsCheckbox}" HorizontalAlignment="Left" Margin="10,102,0,0" VerticalAlignment="Top" FontSize="12"/>
+        <CheckBox x:Name="elseIfCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsElseIfCheckbox}" HorizontalAlignment="Left" Margin="10,128,0,0" VerticalAlignment="Top" FontSize="12"/>
 
         <Button x:Name="formatButton" Content="{DynamicResource ApplyButton}" IsDefault="True" HorizontalAlignment="Right" Width="auto" Click="FormatClick" VerticalAlignment="Bottom" Margin="0,0,10,10"/>
     </Grid>
 </hc:Window>
+

--- a/SkEditorPlus/Windows/FormattingWindow.xaml.cs
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace SkEditorPlus.Windows
             InitializeComponent();
             instance = this;
             this.skEditor = skEditor;
+            _spaceValue = 4;
             textEditor = skEditor.GetMainWindow().GetFileManager().GetTextEditor();
             BackgroundFixManager.FixBackground(this);
 
@@ -47,6 +48,7 @@ namespace SkEditorPlus.Windows
         {
             if (variablesCheckBox.IsChecked == true) FixDotVariables();
             if (spacesCheckBox.IsChecked == true) SpacesToTabs();
+            if (tabsCheckBox.IsChecked == true) TabsToSpaces();
             if (commentsCheckBox.IsChecked == true) RemoveComments();
             if (elseIfCheckBox.IsChecked == true) FixElseIf();
 
@@ -114,6 +116,11 @@ namespace SkEditorPlus.Windows
             ConvertSpacesToTabs(spacingAmount);
         }
 
+        private void TabsToSpaces()
+        {
+            ConvertTabsToSpaces(_spaceValue);
+        }
+
         private int DetectSpacingAmount() {
             var lines = textEditor.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
@@ -174,6 +181,36 @@ namespace SkEditorPlus.Windows
             catch { }
         }
 
+        private void ConvertTabsToSpaces(int spacePerTab)
+        {
+            try
+            {
+                var lines = textEditor.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+                var newLines = new List<string>();
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string lineToReplace = lines[i];
+
+                    //Don't affect comments
+                    if (lineToReplace.Trim().Length > 0 && lineToReplace.Trim()[0] == '#')
+                    {
+                        newLines.Add(lineToReplace);
+                        continue;
+                    }
+
+                    string newLine = lineToReplace.Replace("\t", new string(' ', spacePerTab));
+
+                    newLines.Add(newLine);
+                }
+
+                string newCode = string.Join(Environment.NewLine, newLines);
+                textEditor.Document.Text = newCode;
+            }
+            catch { }
+        }
+
         private int GetOffsetByLine(string line)
         {
             int index = textEditor.Text.IndexOf(line);
@@ -205,5 +242,64 @@ namespace SkEditorPlus.Windows
             code = string.Join(Environment.NewLine, modifiedLines);
             textEditor.Document.Text = code;
         }
+
+private int _spaceValue = 4;
+
+public int SpaceNumber
+{
+    get {  return _spaceValue; }
+    set
+    {
+        if (value < 1 || value > 9) {
+            return;
+        }
+        //Somewhat hacky solution, but it removes the need for another label, and also will support all locales
+        string number = getAllIntsInString((string) tabsCheckBox.Content);
+        tabsCheckBox.Content = ((string) tabsCheckBox.Content).Replace(number.ToString(), value.ToString());
+        _spaceValue = value;
+    }
+}
+
+private string getAllIntsInString(string inputString) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < inputString.Length; i++)
+    {
+        if (Char.IsDigit(inputString[i]))
+            result.Append(inputString[i]);
+    }
+    return result.ToString();
+}
+
+
+private void spaceUp_Click(object sender, RoutedEventArgs e)
+{
+    SpaceNumber++;
+}
+
+private void spaceDown_Click(object sender, RoutedEventArgs e)
+{
+    SpaceNumber--;
+}
+
+//Make radio button un-checkable
+private bool JustChecked;
+private void Radio_Checked(object sender, RoutedEventArgs e)
+{
+    JustChecked = true;
+}
+
+
+private void Radio_Clicked(object sender, RoutedEventArgs e)
+{
+    if (JustChecked) {
+        JustChecked = false;
+        e.Handled = true;
+        return;
+    }
+    RadioButton s = (RadioButton) sender;
+    if (s.IsChecked == true)
+        s.IsChecked = false;
+}
+
     }
 }


### PR DESCRIPTION
Adds a new "Quick Edit" action that replaces all indenting tabs with a specified amount of spaces.
![image](https://github.com/NotroDev/SkEditorPlus/assets/64995932/6230a43e-bb4c-417c-8f70-154e5a8e38d3)
Users can click the arrows to increase and decrease and amount of spaces.

Other things:
- Space values can be from 1 to 9
- The two options about changing spaces to tabs and vice versa are now radio buttons, however they can be fully unchecked (opposed to regular radio buttons)
- Has been tested on my device, however I'm not sure how different resolutions affect placement of things. It's possible that the up and down button may displaced on some devices. (purely speculation, as I have never used WPF before)