### PR TITLE
Expand on the addon api

### DIFF
--- a/SkEditorPlus/ISkEditorPlusAddon.cs
+++ b/SkEditorPlus/ISkEditorPlusAddon.cs
@@ -1,5 +1,4 @@
-﻿using HandyControl.Controls;
-
+﻿
 namespace SkEditorPlus
 {
     public interface ISkEditorPlusAddon
@@ -29,9 +28,97 @@ namespace SkEditorPlus
             return;
         }
 
+        void OnTabCreate() {
+            return;
+        }
+
+        void OnTabClose() {
+            return;
+        }
+
         void OnUnhandledException()
         {
             return;
         }
+        
+        void OnFileOpened(string fileName) {
+            return;
+        }
+
+        void OnFileSave(string fileName) {
+            return;
+        }
+
+        void OnFileCreate(string fileName) {
+            return;
+        }
+
+        void OnPublish(string url) {
+            return;
+        }
+
+        void OnQuickEdit(QuickEditType type) {
+            return;
+        }
+        enum QuickEditType {
+            CHANGE_DOTS_TO_COLONS, CHANGE_SPACES_TO_TABS, CHANGE_TABS_TO_SPACES, REMOVE_COMMENTS, SHORTEN_ELSE_IF
+        }
+        
+         void OnGenerate(GenerateType type) {
+            return;
+         }
+
+        enum GenerateType {
+            GUI, COMMAND
+        }
+
+        void OnBackPackAdd(string addedString) {
+            return;
+        }
+
+        void OnBackPackRemove(string removedString) {
+            return;
+        }
+
+        void OnBackPackPaste(string pastedString) {
+            return;
+        }
+
+        void OnCompletionAccept(string completion) {
+            return;
+        }
+
+        void OnAddonInstall(string addonName, string author, string version) {
+            return;
+        }
+
+        void OnAddonUninstall(string addonName, string author, string version) {
+            return;
+        }
+
+        void OnAddonUpdate(string addonName, string author, string version) {
+            return;
+        }
+
+        void OnSyntaxDisable() {
+            return;
+        }
+
+        void OnSyntaxChange(string newSyntax) {
+            return;
+        }
+
+        void OnSiteOpen(string name, string url) {
+            return;
+        }
+
+        void OnCheckForUpdates(string currentVersion, string newVersion) {
+            return;
+        }
+
+        void OnExiting() {
+            return;
+        }
+
     }
 }

--- a/SkEditorPlus/Languages/English.xaml
+++ b/SkEditorPlus/Languages/English.xaml
@@ -96,6 +96,7 @@
     
     <system:String x:Key="QuickEditsVariablesCheckbox">Change dots in variables to colons</system:String>
     <system:String x:Key="QuickEditsSpacesCheckbox">Change spaces to tabs</system:String>
+    <system:String x:Key="QuickEditsTabsCheckbox">Change tabs to 4 spaces</system:String>
     <system:String x:Key="QuickEditsCommentsCheckbox">Remove comments</system:String>
     <system:String x:Key="QuickEditsElseIfCheckbox">Shorten "else if"</system:String>
     

--- a/SkEditorPlus/MainWindow.xaml.cs
+++ b/SkEditorPlus/MainWindow.xaml.cs
@@ -226,6 +226,12 @@ namespace SkEditorPlus
         private void OnClosing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             SettingsManager.SaveSettings();
+
+            AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnExiting();
+                });
+
             if (tabControl.Items.Count > 0)
             {
                 if (tabControl.Items.Cast<TabItem>().Any(tab => tab.Header.ToString().EndsWith("*")))
@@ -262,6 +268,10 @@ namespace SkEditorPlus
         private void TabClosed(object sender, EventArgs e)
         {
             GC.Collect();
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnTabClose();
+            });
         }
 
         public FileManager GetFileManager()

--- a/SkEditorPlus/Managers/CompletionManager.cs
+++ b/SkEditorPlus/Managers/CompletionManager.cs
@@ -183,6 +183,11 @@ namespace SkEditorPlus.Managers
                 popup.IsOpen = false;
                 popup = null;
                 e.Handled = true;
+
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnCompletionAccept(newText);
+                });
             }
 
             else if (e.Key == Key.Escape)

--- a/SkEditorPlus/Managers/FileManager.cs
+++ b/SkEditorPlus/Managers/FileManager.cs
@@ -128,6 +128,10 @@ namespace SkEditorPlus.Managers
                     GetTextEditor().Save(saveFile.FileName);
                     ti.ToolTip = saveFile.FileName.ToString();
                     ti.Header = saveFile.SafeFileName;
+                    AddonManager.addons.ForEach(addon =>
+                        {
+                            addon.OnFileCreate(saveFile.FileName);
+                         });
                     OnTabChanged();
                 }
             }
@@ -159,6 +163,10 @@ namespace SkEditorPlus.Managers
                     {
                         CreateFile(openFileDialog.SafeFileNames[index], fileName);
                         GetTextEditor().Load(fileName);
+                        AddonManager.addons.ForEach(addon =>
+                        {
+                            addon.OnFileOpened(fileName);
+                         });
                         if (tabControl.SelectedItem is TabItem ti && ti.Header.ToString().EndsWith("*", StringComparison.Ordinal))
                         {
                             ti.Header = ti.Header.ToString()[..^1];
@@ -562,6 +570,10 @@ namespace SkEditorPlus.Managers
             if (syntax.Equals("none"))
             {
                 GetTextEditor().SyntaxHighlighting = null;
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnSyntaxDisable();
+                });
                 return;
             }
 
@@ -601,6 +613,10 @@ namespace SkEditorPlus.Managers
                     };
                     GetTextEditor().SyntaxHighlighting.MainRuleSet.Spans.Add(span);
                 }
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnSyntaxChange(syntax);
+                });
             }
             catch (Exception e)
             {
@@ -654,6 +670,10 @@ namespace SkEditorPlus.Managers
             var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
             await webBrowser.EnsureCoreWebView2Async(env);
             webBrowser.Source = new Uri(url);
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnSiteOpen(header, url);
+            });
         }
 
         public void Export()
@@ -786,6 +806,11 @@ namespace SkEditorPlus.Managers
 
             tabControl.Items.Add(tabItem);
             ChangeGeometry();
+
+            AddonManager.addons.ForEach(addon =>
+            {
+                addon.OnTabCreate();
+            });
 
         }
 

--- a/SkEditorPlus/Managers/UpdateManager.cs
+++ b/SkEditorPlus/Managers/UpdateManager.cs
@@ -27,6 +27,11 @@ namespace SkEditorPlus.Managers
 
                 var current = MainWindow.Version;
 
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnCheckForUpdates(current, latest);
+                });
+
                 if (latest != current)
                 {
                     string newVersionTitle = (string)Application.Current.FindResource("NewVersion");

--- a/SkEditorPlus/Windows/BackpackWindow.xaml.cs
+++ b/SkEditorPlus/Windows/BackpackWindow.xaml.cs
@@ -74,6 +74,11 @@ namespace SkEditorPlus.Windows
 
             Properties.Settings.Default.BackpackCodes = codes;
             Properties.Settings.Default.Save();
+
+            AddonManager.addons.ForEach(addon =>
+            {
+                addon.OnBackPackAdd(selectedCode);
+            });
         }
 
         private void DeleteCode(object sender, RoutedEventArgs e)
@@ -95,6 +100,10 @@ namespace SkEditorPlus.Windows
                 {
                     backpackListbox.SelectedIndex = backpackListbox.Items.Count - 1;
                 }
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnBackPackRemove(item.Content.ToString());
+                });
             }
         }
 
@@ -106,6 +115,10 @@ namespace SkEditorPlus.Windows
             string codeToPaste = item.Content.ToString();
 
             textEditor.Document.Insert(textEditor.CaretOffset, codeToPaste);
+            AddonManager.addons.ForEach(addon =>
+            {
+                addon.OnBackPackPaste(codeToPaste);
+            });
         }
     }
 }

--- a/SkEditorPlus/Windows/FormattingWindow.xaml
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml
@@ -10,11 +10,19 @@
     <Grid>
         <CheckBox x:Name="variablesCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsVariablesCheckbox}" HorizontalAlignment="Left" Margin="10,24,0,0" VerticalAlignment="Top"/>
         
-        <CheckBox x:Name="spacesCheckBox" Background="{StaticResource RegionBrush}" ToolTip="Switches from spaces to tabs for indenting" ToolTipService.IsEnabled="True" ToolTipService.InitialShowDelay="10" Content="{DynamicResource QuickEditsSpacesCheckbox}" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top"/>
+        <RadioButton x:Name="spacesCheckBox" Checked="Radio_Checked" Click="Radio_Clicked" GroupName="SpacesAndTabs" Background="{StaticResource RegionBrush}" ToolTip="Switches from spaces to tabs for indenting" ToolTipService.IsEnabled="True" ToolTipService.InitialShowDelay="10" Content="{DynamicResource QuickEditsSpacesCheckbox}" HorizontalAlignment="Left" Margin="10,50,0,0" VerticalAlignment="Top"/>
+
+        <RadioButton x:Name="tabsCheckBox" Checked="Radio_Checked" Click="Radio_Clicked" GroupName="SpacesAndTabs" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsTabsCheckbox}" HorizontalAlignment="Left" Margin="10,76,0,0" VerticalAlignment="Top" FontSize="12"/>
+        <Button x:Name="cmdUp" x:FieldModifier="private" FontSize="10" Content="▲" Width="12"  Background="Transparent" Height="10" Click="spaceUp_Click" Padding="0,-4,0,0" Margin="162,78,1,13" HorizontalAlignment="Left" VerticalAlignment="Top"  BorderThickness="0"  
+    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" />
+        <Button x:Name="cmdDown" x:FieldModifier="private" FontSize="10" Content="▼" Width="12" Height="10"  Background="Transparent" Click="spaceDown_Click" Padding="0,-4,0,0" Margin="162,88,1,3" HorizontalAlignment="Left" VerticalAlignment="Top"  BorderThickness="0"  
+    Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" />
         
-        <CheckBox x:Name="commentsCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsCommentsCheckbox}" HorizontalAlignment="Left" Margin="10,76,0,0" VerticalAlignment="Top" FontSize="12"/>
-        <CheckBox x:Name="elseIfCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsElseIfCheckbox}" HorizontalAlignment="Left" Margin="10,102,0,0" VerticalAlignment="Top" FontSize="12"/>
+        
+        <CheckBox x:Name="commentsCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsCommentsCheckbox}" HorizontalAlignment="Left" Margin="10,102,0,0" VerticalAlignment="Top" FontSize="12"/>
+        <CheckBox x:Name="elseIfCheckBox" Background="{StaticResource RegionBrush}" Content="{DynamicResource QuickEditsElseIfCheckbox}" HorizontalAlignment="Left" Margin="10,128,0,0" VerticalAlignment="Top" FontSize="12"/>
 
         <Button x:Name="formatButton" Content="{DynamicResource ApplyButton}" IsDefault="True" HorizontalAlignment="Right" Width="auto" Click="FormatClick" VerticalAlignment="Bottom" Margin="0,0,10,10"/>
     </Grid>
 </hc:Window>
+

--- a/SkEditorPlus/Windows/FormattingWindow.xaml.cs
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace SkEditorPlus.Windows
             InitializeComponent();
             instance = this;
             this.skEditor = skEditor;
+            _spaceValue = 4;
             textEditor = skEditor.GetMainWindow().GetFileManager().GetTextEditor();
             BackgroundFixManager.FixBackground(this);
 
@@ -47,6 +48,7 @@ namespace SkEditorPlus.Windows
         {
             if (variablesCheckBox.IsChecked == true) FixDotVariables();
             if (spacesCheckBox.IsChecked == true) SpacesToTabs();
+            if (tabsCheckBox.IsChecked == true) TabsToSpaces();
             if (commentsCheckBox.IsChecked == true) RemoveComments();
             if (elseIfCheckBox.IsChecked == true) FixElseIf();
 
@@ -114,6 +116,11 @@ namespace SkEditorPlus.Windows
             ConvertSpacesToTabs(spacingAmount);
         }
 
+        private void TabsToSpaces()
+        {
+            ConvertTabsToSpaces(_spaceValue);
+        }
+
         private int DetectSpacingAmount() {
             var lines = textEditor.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
@@ -174,6 +181,36 @@ namespace SkEditorPlus.Windows
             catch { }
         }
 
+        private void ConvertTabsToSpaces(int spacePerTab)
+        {
+            try
+            {
+                var lines = textEditor.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+                var newLines = new List<string>();
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string lineToReplace = lines[i];
+
+                    //Don't affect comments
+                    if (lineToReplace.Trim().Length > 0 && lineToReplace.Trim()[0] == '#')
+                    {
+                        newLines.Add(lineToReplace);
+                        continue;
+                    }
+
+                    string newLine = lineToReplace.Replace("\t", new string(' ', spacePerTab));
+
+                    newLines.Add(newLine);
+                }
+
+                string newCode = string.Join(Environment.NewLine, newLines);
+                textEditor.Document.Text = newCode;
+            }
+            catch { }
+        }
+
         private int GetOffsetByLine(string line)
         {
             int index = textEditor.Text.IndexOf(line);
@@ -205,5 +242,64 @@ namespace SkEditorPlus.Windows
             code = string.Join(Environment.NewLine, modifiedLines);
             textEditor.Document.Text = code;
         }
+
+private int _spaceValue = 4;
+
+public int SpaceNumber
+{
+    get {  return _spaceValue; }
+    set
+    {
+        if (value < 1 || value > 9) {
+            return;
+        }
+        //Somewhat hacky solution, but it removes the need for another label, and also will support all locales
+        string number = getAllIntsInString((string) tabsCheckBox.Content);
+        tabsCheckBox.Content = ((string) tabsCheckBox.Content).Replace(number.ToString(), value.ToString());
+        _spaceValue = value;
+    }
+}
+
+private string getAllIntsInString(string inputString) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < inputString.Length; i++)
+    {
+        if (Char.IsDigit(inputString[i]))
+            result.Append(inputString[i]);
+    }
+    return result.ToString();
+}
+
+
+private void spaceUp_Click(object sender, RoutedEventArgs e)
+{
+    SpaceNumber++;
+}
+
+private void spaceDown_Click(object sender, RoutedEventArgs e)
+{
+    SpaceNumber--;
+}
+
+//Make radio button un-checkable
+private bool JustChecked;
+private void Radio_Checked(object sender, RoutedEventArgs e)
+{
+    JustChecked = true;
+}
+
+
+private void Radio_Clicked(object sender, RoutedEventArgs e)
+{
+    if (JustChecked) {
+        JustChecked = false;
+        e.Handled = true;
+        return;
+    }
+    RadioButton s = (RadioButton) sender;
+    if (s.IsChecked == true)
+        s.IsChecked = false;
+}
+
     }
 }

--- a/SkEditorPlus/Windows/FormattingWindow.xaml.cs
+++ b/SkEditorPlus/Windows/FormattingWindow.xaml.cs
@@ -90,6 +90,10 @@ namespace SkEditorPlus.Windows
                 code = code.Replace(variableMatch.Value, variable);
             }
             textEditor.Document.Text = code;
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnQuickEdit(ISkEditorPlusAddon.QuickEditType.CHANGE_DOTS_TO_COLONS);
+            });
         }
 
         private void RemoveComments()
@@ -104,6 +108,10 @@ namespace SkEditorPlus.Windows
             {
                 textEditor.Document.Remove(lineToRemove.Offset, lineToRemove.Length);
             }
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnQuickEdit(ISkEditorPlusAddon.QuickEditType.REMOVE_COMMENTS);
+            });
         }
 
 
@@ -114,11 +122,19 @@ namespace SkEditorPlus.Windows
             // Automatically detect the amount of spaces
             int spacingAmount = DetectSpacingAmount();
             ConvertSpacesToTabs(spacingAmount);
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnQuickEdit(ISkEditorPlusAddon.QuickEditType.CHANGE_SPACES_TO_TABS);
+            });
         }
 
         private void TabsToSpaces()
         {
             ConvertTabsToSpaces(_spaceValue);
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnQuickEdit(ISkEditorPlusAddon.QuickEditType.CHANGE_TABS_TO_SPACES);
+            });
         }
 
         private int DetectSpacingAmount() {
@@ -241,6 +257,10 @@ namespace SkEditorPlus.Windows
 
             code = string.Join(Environment.NewLine, modifiedLines);
             textEditor.Document.Text = code;
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnQuickEdit(ISkEditorPlusAddon.QuickEditType.SHORTEN_ELSE_IF);
+            });
         }
 
 private int _spaceValue = 4;

--- a/SkEditorPlus/Windows/Generators/CommandGenerator.xaml.cs
+++ b/SkEditorPlus/Windows/Generators/CommandGenerator.xaml.cs
@@ -89,6 +89,11 @@ namespace SkEditorPlus.Windows.Generators
 
             commandGeneratorWindow.Close();
             editor.CaretOffset = editor.Document.TextLength;
+
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnGenerate(ISkEditorPlusAddon.GenerateType.COMMAND);
+            });
         }
 
         private void OnComboBoxKeyUp(object sender, System.Windows.Input.KeyEventArgs e)

--- a/SkEditorPlus/Windows/Generators/GuiGenerator.xaml.cs
+++ b/SkEditorPlus/Windows/Generators/GuiGenerator.xaml.cs
@@ -98,6 +98,11 @@ namespace SkEditorPlus.Windows.Generators
             guiGeneratorWindow.Close();
 
             editor.CaretOffset = editor.Document.TextLength;
+
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnGenerate(ISkEditorPlusAddon.GenerateType.GUI);
+            });
         }
 
         private void FunctionNameChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)

--- a/SkEditorPlus/Windows/MarketplaceWindow.xaml.cs
+++ b/SkEditorPlus/Windows/MarketplaceWindow.xaml.cs
@@ -15,9 +15,7 @@ using System.IO;
 using System;
 using System.Threading.Tasks;
 using System.Collections.Specialized;
-using HandyControl.Controls;
 using HandyControl.Data;
-using Renci.SshNet;
 
 namespace SkEditorPlus.Windows
 {
@@ -354,6 +352,10 @@ namespace SkEditorPlus.Windows
                     Properties.Settings.Default.InstalledSyntaxes = syntaxes;
                     Properties.Settings.Default.Save();
                 }
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnAddonInstall(item.Name, item.Author, item.Version);
+                });
             }
             catch (Exception ex)
             {
@@ -413,6 +415,10 @@ namespace SkEditorPlus.Windows
                     IconKey = ResourceToken.InfoGeometry
                 });
             }
+            AddonManager.addons.ForEach(addon =>
+            {
+                    addon.OnAddonUninstall(item.Name, item.Author, item.Version);
+            });
         }
 
         public async void UpdateAddon()
@@ -496,6 +502,10 @@ namespace SkEditorPlus.Windows
                         IconKey = ResourceToken.InfoGeometry
                     });
                 }
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnAddonUpdate(item.Name, item.Author, item.Version);
+                });
             }
             catch (Exception ex)
             {

--- a/SkEditorPlus/Windows/PublishWindow.xaml.cs
+++ b/SkEditorPlus/Windows/PublishWindow.xaml.cs
@@ -77,6 +77,10 @@ namespace SkEditorPlus.Windows
             if (response.IsSuccessStatusCode)
             {
                 urlTextBox.Text = responseString;
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnPublish(responseString);
+                });
             }
         }
 
@@ -101,6 +105,10 @@ namespace SkEditorPlus.Windows
                 JObject jsonResult = JObject.Parse(responseString);
                 string url = jsonResult["url"].ToString();
                 urlTextBox.Text = url;
+                AddonManager.addons.ForEach(addon =>
+                {
+                    addon.OnPublish(url);
+                });
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Semi related to #43 

I would like to preface this by saying that I do not know what you had in mind for the addon API, and if this is not to your liking, just close the pr.

This pr would add many more addon api events, and would overall make it more powerful.
**Events Added:**

- OnTabCreate()
- OnTabClose()
- OnFileOpened(fileName)
- OnFileClosed(fileName)
- OnFileSave(fileName)
- OnPublish(url)
- OnQuickEdit(quickEditType) - quickEditType is an enum
- OnGenerate(generateType_ - generateType is an enum
- OnBackPackAdd(addedString)
- OnBackPackRemove(removedString)
- OnBackPackPaste(pastedString)
- OnCompletionAccept(acceptedCompletion)
- OnAddonInstall(addonName, addonAuthor, addonVersion)
- OnAddonUnInstall(addonName, addonAuthor, addonVersion)
- OnAddonUpdate(addonName, addonAuthor, addonVersion)
- OnSyntaxDisable()
- OnSyntaxChange(newSyntaxName)
- OnSiteOpen(name, url) - ex. parser, docs
- OnCheckForUpdates(currentVersion, latestVersion)
- OnExiting()

**This pr also (accidently) adds this, because I am bad at Git.**
Adds a new "Quick Edit" action that replaces all indenting tabs with a specified amount of spaces.
![image](https://github.com/NotroDev/SkEditorPlus/assets/64995932/7a1c6412-6a21-482b-8147-d7a42c1b2497)

