### PR TITLE
Make "skeditor://" code fetching error messages respect language preferences

### DIFF
--- a/SkEditorPlus/Languages/English.xaml
+++ b/SkEditorPlus/Languages/English.xaml
@@ -212,6 +212,9 @@
 
     <system:String x:Key="MarketplaceDownloadError">Something didn't work.{n}Are you connected to the internet?{n}{n}{0}</system:String>
 
+    <system:String x:Key="ScriptWithIDNotFoundError">Script with ID '{0}' not found!</system:String>
+    <system:String x:Key="FailedToSendRequestError">Error while sending request!</system:String>
+
 
     <system:String x:Key="MarketplaceBrowseTab">Browse</system:String>
     <system:String x:Key="MarketplaceInstalledTab">Installed</system:String>

--- a/SkEditorPlus/Languages/Polski.xaml
+++ b/SkEditorPlus/Languages/Polski.xaml
@@ -207,6 +207,9 @@
     <system:String x:Key="EmptyAPIKeyError">Klucz API nie został wprowadzony.</system:String>
     <system:String x:Key="PublishingError">Coś nie zadziałało.{n}Czy masz połączenie z internetem? Czy wkleiłeś prawidłowy klucz API?{n}{n}{0}</system:String>
 
+    <system:String x:Key="ScriptWithIDNotFoundError">Nie znaleziono skryptu o identyfikatorze '{0}'!</system:String>
+    <system:String x:Key="FailedToSendRequestError">Błąd podczas wysyłania żądania!</system:String>
+  
     <system:String x:Key="MarketplaceBrowseTab">Przeglądaj</system:String>
     <system:String x:Key="MarketplaceInstalledTab">Zainstalowane</system:String>
     <system:String x:Key="MarketplaceUpdatesTab">Aktualizacje</system:String>

--- a/SkEditorPlus/Utilities/CodeFromWeb.cs
+++ b/SkEditorPlus/Utilities/CodeFromWeb.cs
@@ -32,7 +32,6 @@ namespace SkEditorPlus.Utilities
 
             if (response.Content.Headers.ContentType.MediaType != "text/plain")
             {
-                Console.WriteLine("hio");
                 HandyControl.Controls.MessageBox.Error((Application.Current.FindResource("ScriptWithIDNotFoundError") as string).Replace("{0}", id));
                 return null;
             }

--- a/SkEditorPlus/Utilities/CodeFromWeb.cs
+++ b/SkEditorPlus/Utilities/CodeFromWeb.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Ink;
 
 namespace SkEditorPlus.Utilities
@@ -24,14 +25,15 @@ namespace SkEditorPlus.Utilities
             }
             catch (HttpRequestException)
             {
-                MessageBox.Error("Błąd podczas wysyłania żądania.");
+                HandyControl.Controls.MessageBox.Error(Application.Current.FindResource("FailedToSendRequestError") as string);
                 return null;
             }
             string content = await response.Content.ReadAsStringAsync();
 
             if (response.Content.Headers.ContentType.MediaType != "text/plain")
             {
-                MessageBox.Error("Nie znaleziono skryptu o podanym ID.");
+                Console.WriteLine("hio");
+                HandyControl.Controls.MessageBox.Error((Application.Current.FindResource("ScriptWithIDNotFoundError") as string).Replace("{0}", id));
                 return null;
             }
 


### PR DESCRIPTION
When fetching code via "skeditor://", make it so it the error messages update based on language preferences. I only added English and Polish, because I don't speak any language other than English, and the polish one was kind of already there. (I changed it a little bit, so if the polish translation may be a little wrong)